### PR TITLE
zen-browser 1.0.1-a.6

### DIFF
--- a/home/hyprland/hyprland.nix
+++ b/home/hyprland/hyprland.nix
@@ -84,8 +84,9 @@ in {
     [
       # General
       "$mod,Q,killactive,"
-      "$smod,F,togglefloating,"
-      "$mod,F,fullscreen,0"
+      "$mod,F,fullscreen,1"
+      "$smod,F,fullscreen,0"
+      "$cmod,F,togglefloating,"
       "$mod,Tab,exec,hyprkool toggle-overview"
       "CTRL SHIFT,Escape,exec,${terminal} btop"
       # Applications

--- a/home/nvim/default.nix
+++ b/home/nvim/default.nix
@@ -10,8 +10,8 @@ with lib; let
 in {
   options.modules.nvim = {enable = mkEnableOption "nvim";};
   config = mkIf cfg.enable {
-    home.packages = with pkgs; [
-      unstable.neovim
+    home.packages = with pkgs.unstable; [
+      neovim
 
       # Rust build systems
       rustup
@@ -26,24 +26,26 @@ in {
       nodejs_22
       go
       ocaml
-      unstable.zig
+      zig
 
       # Erlang
-      unstable.gleam
+      gleam
       erlang
       rebar3
       elixir
 
       # Python
-      ruff
-      pylyzer
+      # ruff
+      # pylyzer
+      python312Packages.python-lsp-server
+      python312Packages.pylsp-rope
 
       # Lsp
       lua-language-server
       nil
       elixir-ls
       tailwindcss-language-server
-      unstable.zls
+      zls
 
       # Linters
       eslint_d

--- a/modules/configuration.nix
+++ b/modules/configuration.nix
@@ -100,7 +100,6 @@
   # Set environment variables
   environment.variables = {
     XDG_CONFIG_HOME = "$HOME/.config";
-    EDITOR = "nvim";
     SHELL = lib.getExe pkgs.fish;
     DIRENV_LOG_FORMAT = "";
     ANKI_WAYLAND = "1";

--- a/modules/configuration.nix
+++ b/modules/configuration.nix
@@ -99,6 +99,7 @@
 
   # Set environment variables
   environment.variables = {
+    XDG_CONFIG_HOME = "$HOME/.config";
     EDITOR = "nvim";
     SHELL = lib.getExe pkgs.fish;
     DIRENV_LOG_FORMAT = "";

--- a/overlays/zen-browser/default.nix
+++ b/overlays/zen-browser/default.nix
@@ -57,12 +57,12 @@
     ]);
 in
   pkgs.stdenv.mkDerivation rec {
-    version = "1.0.1-a.1";
+    version = "1.0.1-a.6";
     pname = "zen-browser";
 
     src = builtins.fetchTarball {
       url = "https://github.com/zen-browser/desktop/releases/download/${version}/zen.linux-specific.tar.bz2";
-      sha256 = "sha256:0ckd2ra2clhly8s0xk11ni7k1mnw0l9y061zp4h9xyxf4gkz898f";
+      sha256 = "sha256:0jkzdrsd1qdw3pwdafnl5xb061vryxzgwmvp1a6ghdwgl2dm2fcz";
     };
 
     desktopSrc = ./.;


### PR DESCRIPTION
- **fix: added XDG_CONFIG_HOME**
- **fix: rebound fullscreen and floating**
- **fix: fix neovim deps and env**
- **fix: version bump 1.0.1-a.1 -> 1.0.1.a.6**
