### PR TITLE
Uppdating to fix critical security flaw in css (9.8)

### DIFF
--- a/overlays/zen-browser/default.nix
+++ b/overlays/zen-browser/default.nix
@@ -62,7 +62,7 @@ in
 
     src = builtins.fetchTarball {
       url = "https://github.com/zen-browser/desktop/releases/download/${version}/zen.linux-specific.tar.bz2";
-      sha256 = "sha256:0jkzdrsd1qdw3pwdafnl5xb061vryxzgwmvp1a6ghdwgl2dm2fcz";
+      sha256 = "sha256:1f4ym15gmwwxmgpwsl09a2rq1cwgybn0f715pj2icn2kmliasdkn";
     };
 
     desktopSrc = ./.;

--- a/overlays/zen-browser/default.nix
+++ b/overlays/zen-browser/default.nix
@@ -57,7 +57,7 @@
     ]);
 in
   pkgs.stdenv.mkDerivation rec {
-    version = "1.0.1-a.6";
+    version = "1.0.1-a.9";
     pname = "zen-browser";
 
     src = builtins.fetchTarball {


### PR DESCRIPTION
https://www.mozilla.org/en-US/security/advisories/mfsa2024-51/