### PR TITLE
html lsp

### DIFF
--- a/home/nvim/default.nix
+++ b/home/nvim/default.nix
@@ -45,8 +45,9 @@ in {
       elixir-ls
       tailwindcss-language-server
       zls
-      superhtml
       htmx-lsp
+      vscode-langservers-extracted
+      emmet-ls
 
       # Linters
       eslint_d

--- a/home/nvim/default.nix
+++ b/home/nvim/default.nix
@@ -45,6 +45,8 @@ in {
       elixir-ls
       tailwindcss-language-server
       zls
+      superhtml
+      htmx-lsp
 
       # Linters
       eslint_d


### PR DESCRIPTION
Added language servers for html and lsp while neovim is enabled.
Also added emmet for extra support.

VSC*de has all of the language servers for **css, html, js**, etcetera packaged into one package.
